### PR TITLE
Move cloud native apps before CLI hands-on

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,13 +75,13 @@
                  data-separator-notes="^Note:"
                  data-charset="utf-8">
         </section>
-        <section data-markdown="markdown/06_handson.md"
+        <section data-markdown="markdown/06_cloudnative.md"
                  data-separator="==="
                  data-separator-vertical="^---$"
                  data-separator-notes="^Note:"
                  data-charset="utf-8">
         </section>
-        <section data-markdown="markdown/07_cloudnative.md"
+        <section data-markdown="markdown/07_handson.md"
                  data-separator="==="
                  data-separator-vertical="^---$"
                  data-separator-notes="^Note:"

--- a/welcome.md
+++ b/welcome.md
@@ -5,10 +5,9 @@
   * Break at some suitable time
 * Afternoon: More technical topics 
   * 12:00 - 13:00 Lunch (own expense)
-  * 13:00 - 14:30 Terminology, architecture and CLI hands-on
-  * 14:30 - 14:45 Break
-  * 14:45 - 15:15 Cloud native apps
-  * 15:15 - 17:00 CLI hands-on, porting own apps, etc.
+  * 13:00 - 14:00 Terminology, architecture and cloud native apps
+  * 14:00 - 14:15 Break
+  * 14:15 - 17:00 CLI hands-on
 * Slides: []()
 * Exercises: [Digipalvelutehdas GitHub](https://github.com/Digipalvelutehdas/container-course-material)
 * Chat: []()


### PR DESCRIPTION
In order to not interrupt people's flow while working on the exercises,
move the cloud native apps part of the presentation before the CLI
hands-on.